### PR TITLE
Support noble only

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,6 +1,0 @@
-gz-utils4 (3.999.999-1~jammy) jammy; urgency=medium
-
-  * Stub to be removed after first entry
-
- -- Carlos Aguero <caguero@openrobotics.org>  Tue, 08 Oct 2024 21:02:02 +0200
-

--- a/jammy/debian/compat
+++ b/jammy/debian/compat
@@ -1,1 +1,0 @@
-../../ubuntu/debian/compat

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,0 @@
-../../ubuntu/debian/control

--- a/jammy/debian/copyright
+++ b/jammy/debian/copyright
@@ -1,1 +1,0 @@
-../../ubuntu/debian/copyright

--- a/jammy/debian/docs
+++ b/jammy/debian/docs
@@ -1,1 +1,0 @@
-../../ubuntu/debian/docs

--- a/jammy/debian/format
+++ b/jammy/debian/format
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source/format

--- a/jammy/debian/libgz-utils4-cli-dev.install
+++ b/jammy/debian/libgz-utils4-cli-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-utils-cli-dev.install

--- a/jammy/debian/libgz-utils4-dev.install
+++ b/jammy/debian/libgz-utils4-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-utils-dev.install

--- a/jammy/debian/libgz-utils4-log-dev.install
+++ b/jammy/debian/libgz-utils4-log-dev.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-utils-log-dev.install

--- a/jammy/debian/libgz-utils4-log.install
+++ b/jammy/debian/libgz-utils4-log.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-utils-log.install

--- a/jammy/debian/libgz-utils4.install
+++ b/jammy/debian/libgz-utils4.install
@@ -1,1 +1,0 @@
-../../ubuntu/debian/libgz-utils.install

--- a/jammy/debian/rules
+++ b/jammy/debian/rules
@@ -1,1 +1,0 @@
-../../ubuntu/debian/rules

--- a/jammy/debian/source
+++ b/jammy/debian/source
@@ -1,1 +1,0 @@
-../../ubuntu/debian/source

--- a/jammy/debian/watch
+++ b/jammy/debian/watch
@@ -1,1 +1,0 @@
-../../ubuntu/debian/watch


### PR DESCRIPTION
The next Gazebo distribution will support only noble and newer versions of Ubuntu. This PR adds noble and removes older distributions.