### PR TITLE
Remove version number from install rules

### DIFF
--- a/ubuntu/debian/libgz-utils-cli-dev.install
+++ b/ubuntu/debian/libgz-utils-cli-dev.install
@@ -1,4 +1,4 @@
 usr/include/*/*/*/utils/cli/*
 usr/include/*/*/*/utils/cli.hh
-usr/lib/*/pkgconfig/*-utils[0-99]-cli.pc
-usr/lib/*/cmake/*-utils[0-99]-cli/*
+usr/lib/*/pkgconfig/*-utils-cli.pc
+usr/lib/*/cmake/*-utils-cli/*

--- a/ubuntu/debian/libgz-utils-dev.install
+++ b/ubuntu/debian/libgz-utils-dev.install
@@ -1,9 +1,9 @@
-usr/include/*/utils[0-99]/gz/utils/detail/*.hh
-usr/include/*/utils[0-99]/gz/utils/detail/*.h
-usr/include/*/utils[0-99]/*/utils.hh
-usr/include/*/utils[0-99]/*/utils/*.hh
-usr/lib/*/pkgconfig/*-utils[0-99].pc
-usr/lib/*/cmake/*-utils[0-99]/*-utils*
-usr/lib/*/cmake/*-utils[0-99]-all/*-utils*
-usr/lib/*/lib*-utils[0-99].so
+usr/include/*/utils*/gz/utils/detail/*.hh
+usr/include/*/utils*/gz/utils/detail/*.h
+usr/include/*/utils*/*/utils.hh
+usr/include/*/utils*/*/utils/*.hh
+usr/lib/*/pkgconfig/*-utils.pc
+usr/lib/*/cmake/*-utils/*-utils*
+usr/lib/*/cmake/*-utils-all/*-utils*
+usr/lib/*/lib*-utils.so
 usr/share/gz/*/*

--- a/ubuntu/debian/libgz-utils-log-dev.install
+++ b/ubuntu/debian/libgz-utils-log-dev.install
@@ -1,4 +1,4 @@
 usr/include/*/*/*/utils/log/*
-usr/lib/*/pkgconfig/*-utils[0-99]-log.pc
-usr/lib/*/cmake/*-utils[0-99]-log/*
-usr/lib/*/lib*-utils[0-99]-log.so
+usr/lib/*/pkgconfig/*-utils-log.pc
+usr/lib/*/cmake/*-utils-log/*
+usr/lib/*/lib*-utils-log.so

--- a/ubuntu/debian/libgz-utils-log.install
+++ b/ubuntu/debian/libgz-utils-log.install
@@ -1,1 +1,1 @@
-usr/lib/*/lib*-utils[0-99]-log.so.*
+usr/lib/*/lib*-utils-log.so.*

--- a/ubuntu/debian/libgz-utils.install
+++ b/ubuntu/debian/libgz-utils.install
@@ -1,1 +1,1 @@
-usr/lib/*/lib*-utils[0-99].so.*
+usr/lib/*/lib*-utils.so.*


### PR DESCRIPTION
Remove version numbers from package names in install rules. Needed to fix nightly build as a follow up to https://github.com/gazebosim/gz-utils/pull/171.

* Before: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-utils4-debbuilder&build=75)](https://build.osrfoundation.org/job/gz-utils4-debbuilder/75/) https://build.osrfoundation.org/job/gz-utils4-debbuilder/75/

* After: [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-utils4-debbuilder&build=76)](https://build.osrfoundation.org/job/gz-utils4-debbuilder/76/) https://build.osrfoundation.org/job/gz-utils4-debbuilder/76/