### PR TITLE
Configure with GZ_UTILS_VENDOR_CLI11=ON

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -12,6 +12,7 @@ DEB_HOST_ARCH := $(shell dpkg-architecture -qDEB_HOST_ARCH)
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
+	    -DGZ_UTILS_VENDOR_CLI11=ON \
 	    -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
 override_dh_strip:


### PR DESCRIPTION
Needed to fix a test failure on 24.04 that doesn't occur with version 2.5.0 of cli11 in homebrew-core on macOS.

See https://github.com/gazebosim/gz-sim/pull/2910#issuecomment-2896071272.

An alternative is to revert https://github.com/gazebosim/gz-utils/pull/167.